### PR TITLE
homie: fix filter time reset implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "systemair-save-tools"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-stream",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systemair-save-tools"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 license = "MIT"
 authors = ["Simonas Kazlauskas <systemair@kazlauskas.me>"]

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761907660,
-        "narHash": "sha256-kJ8lIZsiPOmbkJypG+B5sReDXSD1KGu2VEPNqhRa/ew=",
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.91.0"
+channel = "1.93.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]

--- a/src/homie.rs
+++ b/src/homie.rs
@@ -36,6 +36,7 @@ pub(crate) enum EventResult {
     HomieNotSet { node_id: HomieID, prop_idx: usize, why: &'static str },
     HomieSet { node_id: HomieID, prop_idx: usize, operation: Operation, response: ResponseKind },
     ActionResponse { node_id: HomieID, prop_idx: usize, value: Box<DynPropertyValue> },
+    ActionFailure { node_id: HomieID, prop_idx: usize, why: &'static str },
 }
 
 #[derive(Debug)]
@@ -621,6 +622,12 @@ impl SystemAirDevice {
             }
             EventResult::ActionResponse { node_id, prop_idx, value } => {
                 self.handle_value_change(&node_id, prop_idx, &*value).await?;
+            }
+            EventResult::ActionFailure { node_id, prop_idx, why } => {
+                let node = self.nodes.get(&node_id);
+                let node = node.ok_or_else(|| Error::UnknownNode(node_id.clone()))?;
+                let prop = &node.properties()[prop_idx];
+                tracing::error!(%node_id, prop_id = %prop.prop_id, why, "action did not succeed");
             }
             EventResult::Periodic { .. } => unreachable!("EventResult::Periodic"),
             EventResult::HomieSet { .. } => unreachable!("EventResult::HomieSet"),

--- a/src/homie/filter_node.rs
+++ b/src/homie/filter_node.rs
@@ -115,9 +115,31 @@ impl ActionPropertyValue for ReplaceAction {
         modbus: std::sync::Arc<crate::connection::Connection>,
     ) -> std::pin::Pin<Box<super::EventStream>> {
         Box::pin(async_stream::stream! {
-            let register = const { RegisterIndex::from_name("FILTER_PERIOD_SET").unwrap() };
+            // Resetting the filter period can happen via setting of the `FILTER_PERIOD` to the
+            // next replacement deadline in months. We have this value cached in the background,
+            // but it is inconvenient to get to said cache. So we'll "just" read it out manually.
+            let register = const { RegisterIndex::from_name("FILTER_PERIOD").unwrap() };
             let address = register.address();
-            let operation = modbus::Operation::SetHoldings { address, values: vec![1] };
+            let operation = modbus::Operation::GetHoldings { address, count: 1 };
+            let response = modbus.send_retrying(operation.clone()).await?;
+            let modbus::ResponseKind::GetHoldings { values } = response.kind else {
+                yield Ok(EventResult::ActionFailure {
+                    node_id,
+                    prop_idx,
+                    why: "could not read original value for FILTER_PERIOD register"
+                });
+                return;
+            };
+            let Some(value) = values.as_array::<2>() else {
+                yield Ok(EventResult::ActionFailure {
+                    node_id,
+                    prop_idx,
+                    why: "FILTER_PERIOD read responded with wrong number of bytes?"
+                });
+                return;
+            };
+            let value = u16::from_be_bytes(*value);
+            let operation = modbus::Operation::SetHoldings { address, values: vec![value] };
             let _response = modbus.send_retrying(operation.clone()).await?.kind;
             // SUBTLE: _response could be a server exception. We still signal to the action invoker
             // that we received the command. They will be able to tell if this had a desired effect
@@ -127,7 +149,7 @@ impl ActionPropertyValue for ReplaceAction {
                 prop_idx,
                 value: Box::new(Self)
             });
-            let operation = modbus::Operation::GetHoldings { address, count: 3 };
+            let operation = modbus::Operation::GetHoldings { address, count: 7 };
             let response = modbus.send_retrying(operation.clone()).await?.kind;
             yield Ok(EventResult::HomieSet { node_id, prop_idx, operation, response });
         })

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -553,7 +553,7 @@ macro_rules! for_each_register {
             7001: U16, RW, "FILTER_PERIOD", min = 3, max = 15;
             7002: U16, RW, "FILTER_REPLACEMENT_TIME_L";
             7003: U16, RW, "FILTER_REPLACEMENT_TIME_H";
-            7004: U16, RW, "FILTER_PERIOD_SET";
+            7004: U16, R_, "FILTER_PERIOD_SET";
             7005: U16, R_, "FILTER_REMAINING_TIME_L";
             7006: U16, R_, "FILTER_REMAINING_TIME_H";
             7007: U16, R_, "FILTER_ALARM_WAS_DETECTED";


### PR DESCRIPTION
Weirdly, `FILTER_PERIOD_SET` despite its description is a read-only register and does not appear to do anything at all. In order to reset the filter timing you have to set `FILTER_PERIOD` to the number of months in which the filter needs to be replaced next… That also, unfortunately, means you cannot really adjust this parameter without additional side-effects, which maybe suggests that it should be exposed in some other way?

That said, I'm finding myself wanting a sub-command that could modify this without having to go through MQTT...